### PR TITLE
From: https://github.com/smjs/samtools/commit/e208b6d0c47083fa8d778aa…

### DIFF
--- a/consumer.c
+++ b/consumer.c
@@ -428,6 +428,7 @@ consumer_run(void *arg)
           }
           else if((NULL == c->reader && QUEUE_STATE_EOF == c->input->state) 
              || (NULL != c->reader && 1 == c->reader->is_done)) { // TODO: does this need to be synced?
+			  block_destroy(b);
               break;
           }
           else {
@@ -460,6 +461,7 @@ consumer_run(void *arg)
               exit(1);
           }
           else {
+			  block_destroy(b);
               break;
           }
       }


### PR DESCRIPTION
…9cc2684d1afc84881

"Fix for small memory leak in the consumer code: When the consumer is
processing blocks it takes them off the queue. If at that instant the
consumer's input or output queues go into QUEUE_STATE_EOF the block is
not in the queue so won't get freed by queue_destroy, so needs to be
freed in the consumer. It's two one line additions (block_destroy calls)
in consumer_run."

Fixes #2 .
