### PR TITLE
Add .gitignore for some build objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+autom4te.cache
+aclocal.m4
+stamp-h1
+configure
+config.*
+pbgzip.git.rev
+Makefile.in
+Makefile
+.deps
+*.o
+pbgzip


### PR DESCRIPTION
Just to keep `git status` clean after building, avoid accidentally adding temporary files etc.
